### PR TITLE
[fix/#31] fix: protected routing 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,12 @@
-import {createBrowserRouter, RouterProvider, redirect} from "react-router-dom";
+import {createBrowserRouter, RouterProvider, redirect, Outlet} from "react-router-dom";
 import Main from "./routes/Main.jsx";
 import NewProject from "./routes/NewProject.jsx";
 import ProjectDetail from "./routes/ProjectDetail.jsx";
 import Login from "./routes/Login.jsx";
 import Register from "./routes/Register.jsx";
 import RootLayout from "./RootLayout.jsx";
-import ErrorPage from "./components/common/Errorpage.jsx";
+import RouterErrorBoundary from "./components/common/RouterErrorBoundary.jsx";
+import RootErrorBoundary from "./components/common/RootErrorBoundary.jsx";
 
 const tokenLoader = () => {
     const token = localStorage.getItem('token');
@@ -20,27 +21,42 @@ const protectedLoader = () => {
     return null;
 };
 
+const ProtectedRoutes = () => {
+    return <Outlet />;
+};
+
 const router = createBrowserRouter([
     {
         path: '/',
         element: <RootLayout />,
         id: 'root',
         loader: tokenLoader,
-        errorElement: <ErrorPage />,
+        errorElement: <RootErrorBoundary />,
         children: [
-            { index: true, element: <Main /> },
-            { path: 'login', element: <Login /> },
-            { path: 'register', element: <Register /> },
             {
-                path: 'projects',
-                element: <NewProject />,
-                loader: protectedLoader
+                path: 'login',
+                element: <Login />
             },
             {
-                path: 'projects/:projectId',
-                element: <ProjectDetail />,
-                loader: protectedLoader
+                path: 'register',
+                element: <Register />
             },
+            {
+                element: <ProtectedRoutes />,
+                loader: protectedLoader,
+                errorElement: <RouterErrorBoundary />,
+                children: [
+                    { index: true, element: <Main /> },
+                    {
+                        path: 'projects',
+                        element: <NewProject />
+                    },
+                    {
+                        path: 'projects/:projectId',
+                        element: <ProjectDetail />
+                    },
+                ]
+            }
         ],
     },
 ]);

--- a/src/components/common/Errorpage.jsx
+++ b/src/components/common/Errorpage.jsx
@@ -2,24 +2,28 @@ import { useRouteError } from 'react-router-dom';
 import Logo from "../../assets/BoWS_logo.svg";
 import React from "react";
 
-function ErrorPage() {
-    const error = useRouteError();
-
+function ErrorPage({ error }) {
     let title = 'An error occurred!';
     let message = 'Something went wrong.';
+    const status = error.response.status;
 
-    if (error.status === 404) {
+    console.log(status);
+
+    if (status === 404) {
         title = '404 - 페이지를 찾을 수 없습니다!';
         message = '요청하신 리소스 또는 페이지를 찾을 수 없습니다.';
-    } else if (error.status === 400) {
+    } else if (status === 400) {
         title = '400 - 잘못된 요청입니다!';
         message = '요청에 문제가 있습니다. 다시 확인해 주세요.';
-    } else if (error.status === 401) {
+    } else if (status === 401) {
         title = '401 - 권한이 없습니다!';
         message = '이 페이지에 접근할 권한이 없습니다. 로그인이 필요할 수 있습니다.';
-    } else if (error.status === 500) {
+    } else if (status === 500) {
         title = '500 - 서버 오류!';
         message = '서버에 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+    } else if (status === 403) {
+        title = '403 - 페이지에 대한 권한이 없습니다!';
+        message = '해당 리소스에 대한 권한이 없습니다';
     }
 
     return (

--- a/src/components/common/RootErrorBoundary.jsx
+++ b/src/components/common/RootErrorBoundary.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useRouteError } from "react-router-dom";
+import Logo from "../../assets/BoWS_logo.svg";
+
+const RootErrorBoundary = () => {
+    const error = useRouteError();
+    return (
+        <div className="flex flex-col items-center h-screen justify-center gap-10">
+            <div className="flex flex-col flex-grow-[3] text-3xl justify-end gap-10">
+                <img className="h-[100px] mx-auto" alt="Service Logo" src={Logo}/>
+                <h2 className="text-center">현재 오류가 발생했습니다.</h2>
+            </div>
+            <div className="flex flex-grow-[3] text-xl items-start">
+                <p>문제의 세부 사항: {error.message || JSON.stringify(error)}</p>
+            </div>
+            <button
+                className="mt-4 rounded-md bg-blue-500 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-400"
+                onClick={() => (window.location.href = "/")}
+            >
+                앱 새로 시작하기
+            </button>
+            <div className="flex flex-grow-[1]"></div>
+        </div>
+    );
+};
+
+export default RootErrorBoundary;

--- a/src/components/common/RouterErrorBoundary.jsx
+++ b/src/components/common/RouterErrorBoundary.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { isRouteErrorResponse, useRouteError } from "react-router-dom";
+import ErrorPage from './ErrorPage';
+
+const RouterErrorBoundary = () => {
+    const error = useRouteError();
+
+    return <ErrorPage error={error} />;
+};
+
+export default RouterErrorBoundary;

--- a/src/components/projectDetail/ServiceList.jsx
+++ b/src/components/projectDetail/ServiceList.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import ServiceItem from "./ServiceItem.jsx";
 import axios from "axios";
 import {useParams, useRouteLoaderData} from "react-router-dom";
@@ -6,17 +6,17 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faClock, faGlobe, faRedo} from "@fortawesome/free-solid-svg-icons";
 import {calculateAge} from "../../utils/dateUtils.js";
 import {SERVER_URL} from '../../constants/network.js'
+import {useAsyncError} from "../../hooks/useAsyncError.js";
 
 const ServiceList = () => {
-
-    const params = useParams();
-    const projectId = params.projectId;
+    const { projectId } = useParams();
     const { token } = useRouteLoaderData('root');
     const [projectDetail, setProjectDetail] = useState({});
     const [serviceMetadata, setServiceMetadata] = useState([]);
     const projectAge = calculateAge(projectDetail.projectCreatedTime);
+    const throwAsyncError = useAsyncError();
 
-    const fetchServices = async () => {
+    const fetchServices = useCallback(async () => {
         try {
             const response = await axios.get(`${SERVER_URL}/api/projects/${projectId}`, {
                 headers: {
@@ -28,13 +28,13 @@ const ServiceList = () => {
             setServiceMetadata(response.data.serviceMetadata);
             console.log(response.data.serviceMetadata);
         } catch (error) {
-            console.log(error.message);
+            throwAsyncError(error);
         }
-    }
+    }, [projectId, token, throwAsyncError]);
 
     useEffect(() => {
         fetchServices();
-    }, []);
+    }, [fetchServices]);
 
     const handleRefresh = () => {
         window.location.reload();

--- a/src/components/projectList/ProjectList.jsx
+++ b/src/components/projectList/ProjectList.jsx
@@ -3,11 +3,13 @@ import ProjectItem from './ProjectItem.jsx';
 import axios from "axios";
 import {SERVER_URL} from '../../constants/network.js'
 import {useRouteLoaderData} from "react-router-dom";
+import {useAsyncError} from "../../hooks/useAsyncError.js";
 
 const ProjectList = () => {
     const { token } = useRouteLoaderData('root');
     const [projects, setProjects] = useState([]);
     const numOfProjects = projects.length;
+    const throwAsyncError = useAsyncError();
 
     const fetchProjects = async () => {
         try {
@@ -19,7 +21,7 @@ const ProjectList = () => {
             });
             setProjects(response.data);
         } catch (error) {
-            console.log(error.message);
+            throwAsyncError(error);
         }
     };
 

--- a/src/hooks/useAsyncError.js
+++ b/src/hooks/useAsyncError.js
@@ -1,0 +1,13 @@
+import { useState, useCallback } from 'react';
+
+export function useAsyncError() {
+    const [_, setError] = useState();
+    return useCallback(
+        (e) => {
+            setError(() => {
+                throw e;
+            });
+        },
+        [setError],
+    );
+}


### PR DESCRIPTION
- ProtectedRoutes에 <Main /> 추가
- ErrorBoundaries로 에러 응답 반환 시 에러페이지로 라우팅 로직 구현
- async에 대한 에러처리는 커스텀 훅을 만들어 라우터까지 에러 전파, 라우터에서 에러 페이지로 라우팅되도록 설정